### PR TITLE
서버 실행시 Index create-drop 전략 및 Post 반환에 UserNameInfo 일급 컬렉션을 이용하여 반환 리팩터링

### DIFF
--- a/src/main/java/com/sejong/elasticservice/common/config/ElasticsearchIndexInitializer.java
+++ b/src/main/java/com/sejong/elasticservice/common/config/ElasticsearchIndexInitializer.java
@@ -17,36 +17,40 @@ public class ElasticsearchIndexInitializer {
     public ApplicationRunner createCsKnowledgeIndex(ElasticsearchOperations ops) {
         return args -> {
             IndexOperations indexOps = ops.indexOps(CsKnowledgeDocument.class);
-            if(!indexOps.exists()) {
-                indexOps.createWithMapping();
+            if(indexOps.exists()) {
+                indexOps.delete();
             }
+            indexOps.createWithMapping();
         };
     }
     @Bean
     public ApplicationRunner createProjectIndex(ElasticsearchOperations ops) {
         return args -> {
             IndexOperations indexOps = ops.indexOps(ProjectDocument.class);
-            if(!indexOps.exists()) {
-                indexOps.createWithMapping();
+            if(indexOps.exists()) {
+                indexOps.delete();
             }
+            indexOps.createWithMapping();
         };
     }
     @Bean
     public ApplicationRunner createNewsIndex(ElasticsearchOperations ops) {
         return args -> {
             IndexOperations indexOps = ops.indexOps(NewsDocument.class);
-            if(!indexOps.exists()) {
-                indexOps.createWithMapping();
+            if(indexOps.exists()) {
+                indexOps.delete();
             }
+            indexOps.createWithMapping();
         };
     }
     @Bean
     public ApplicationRunner createDocumentIndex(ElasticsearchOperations ops) {
         return args -> {
             IndexOperations indexOps = ops.indexOps(DocumentDocument.class);
-            if(!indexOps.exists()) {
-                indexOps.createWithMapping();
+            if(indexOps.exists()) {
+                indexOps.delete();
             }
+            indexOps.createWithMapping();
         };
     }
 }

--- a/src/main/java/com/sejong/elasticservice/common/dto/UserInfo.java
+++ b/src/main/java/com/sejong/elasticservice/common/dto/UserInfo.java
@@ -1,0 +1,28 @@
+package com.sejong.elasticservice.common.dto;
+
+import com.sejong.elasticservice.common.embedded.Names;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfo {
+    private String username;
+    private String nickname;
+    private String realname;
+
+    public static UserInfo from(Names names) {
+        if (names == null) {
+            return null;
+        }
+        return UserInfo.builder()
+                .username(names.getUsername())
+                .nickname(names.getNickname())
+                .realname(names.getRealname())
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/elasticservice/domain/UserInfo.java
+++ b/src/main/java/com/sejong/elasticservice/domain/UserInfo.java
@@ -1,0 +1,28 @@
+package com.sejong.elasticservice.domain;
+
+import com.sejong.elasticservice.common.embedded.Names;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfo {
+    private String username;
+    private String nickname;
+    private String realname;
+
+    public static UserInfo from(Names names) {
+        if (names == null) {
+            return null;
+        }
+        return UserInfo.builder()
+                .username(names.getUsername())
+                .nickname(names.getNickname())
+                .realname(names.getRealname())
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/elasticservice/domain/csknowledge/dto/CsKnowledgeSearchDto.java
+++ b/src/main/java/com/sejong/elasticservice/domain/csknowledge/dto/CsKnowledgeSearchDto.java
@@ -1,5 +1,6 @@
 package com.sejong.elasticservice.domain.csknowledge.dto;
 
+import com.sejong.elasticservice.domain.UserInfo;
 import com.sejong.elasticservice.domain.csknowledge.domain.CsKnowledgeDocument;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,8 @@ public class CsKnowledgeSearchDto {
     private String createdAt;
     private long likeCount;
     private long viewCount;
+    
+    private UserInfo writer;
 
     public static CsKnowledgeSearchDto toCsKnowledgeSearchDto(CsKnowledgeDocument document) {
         return CsKnowledgeSearchDto.builder()
@@ -28,6 +31,7 @@ public class CsKnowledgeSearchDto {
                 .createdAt(document.getCreatedAt())
                 .likeCount(document.getLikeCount())
                 .viewCount(document.getViewCount())
+                .writer(UserInfo.from(document.getWriter()))
                 .build();
     }
 }

--- a/src/main/java/com/sejong/elasticservice/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/sejong/elasticservice/domain/document/controller/DocumentController.java
@@ -31,7 +31,7 @@ public class DocumentController {
     @GetMapping("/search")
     @Operation(summary = "Document관련 elastic 내용물 전체 조회 => 현재 정렬 방식은 지원 안함")
     public ResponseEntity<List<DocumentSearchDto>> searchDocuments(
-            @RequestParam String query,
+            @RequestParam(required = false) String query,
             @RequestParam(defaultValue = "5") int size,
             @RequestParam(defaultValue = "0") int page
     ) {

--- a/src/main/java/com/sejong/elasticservice/domain/document/repository/DocumentRepositoryImpl.java
+++ b/src/main/java/com/sejong/elasticservice/domain/document/repository/DocumentRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.sejong.elasticservice.domain.document.repository;
 
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
@@ -57,14 +58,16 @@ public class DocumentRepositoryImpl implements DocumentRepository {
 
     @Override
     public List<DocumentDocument> searchDocuments(String query, int size, int page) {
-        Query multiMatchQuery = MultiMatchQuery.of(m -> m
+        Query textQuery = (query == null || query.isBlank())
+                ? MatchAllQuery.of(m -> m)._toQuery()
+                : MultiMatchQuery.of(m -> m
                 .query(query)
                 .fields("title^3", "description^2", "content")
                 .fuzziness("AUTO")
         )._toQuery();
 
         Query boolQuery = BoolQuery.of(b -> b
-                .must(multiMatchQuery)
+                .must(textQuery)
         )._toQuery();
 
         NativeQuery nativeQuery = NativeQuery.builder()

--- a/src/main/java/com/sejong/elasticservice/domain/news/dto/NewsSearchDto.java
+++ b/src/main/java/com/sejong/elasticservice/domain/news/dto/NewsSearchDto.java
@@ -1,6 +1,6 @@
 package com.sejong.elasticservice.domain.news.dto;
 
-import com.sejong.elasticservice.common.embedded.Names;
+import com.sejong.elasticservice.domain.UserInfo;
 import com.sejong.elasticservice.domain.news.domain.Content;
 import com.sejong.elasticservice.domain.news.domain.NewsDocument;
 import lombok.AllArgsConstructor;
@@ -18,26 +18,29 @@ public class NewsSearchDto {
     private Long id;
     private Content content;
     private String thumbnailPath;
-    private String writerId;
-    private List<String> participantIds;
     private List<String> tags;
     private String createdAt;
     private String updatedAt;
     private long likeCount;
     private long viewCount;
+    
+    private UserInfo writer;
+    private List<UserInfo> participants;
 
     public static NewsSearchDto toNewsSearchDto(NewsDocument nd) {
         return NewsSearchDto.builder()
                 .id(Long.parseLong(nd.getId()))
                 .content(nd.getContent())
                 .thumbnailPath(nd.getThumbnailPath())
-                .writerId(nd.getWriter().getNickname())
-                .participantIds(nd.getParticipants().stream().map(Names::getNickname).toList())
                 .tags(nd.getTags())
                 .createdAt(nd.getCreatedAt())
                 .updatedAt(nd.getUpdatedAt())
                 .likeCount(nd.getLikeCount())
                 .viewCount(nd.getViewCount())
+                .writer(UserInfo.from(nd.getWriter()))
+                .participants(nd.getParticipants() != null 
+                        ? nd.getParticipants().stream().map(UserInfo::from).toList() 
+                        : List.of())
                 .build();
     }
 }

--- a/src/main/java/com/sejong/elasticservice/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/sejong/elasticservice/domain/project/controller/ProjectController.java
@@ -32,8 +32,8 @@ public class ProjectController {
     @GetMapping("/search")
     @Operation(summary = "elastic 내용물 전체 조회 => 현재 정렬 방식은 지원 안함")
     public ResponseEntity<PageResponse<ProjectSearchDto>> searchProjects(
-            @RequestParam String query,
-            @RequestParam ProjectStatus projectStatus,
+            @RequestParam(required = false) String query,
+            @RequestParam(required = false) ProjectStatus projectStatus,
             @RequestParam(defaultValue = "") List<String> categories,
             @RequestParam(defaultValue = "") List<String> techStacks,
             @RequestParam(defaultValue = "LATEST") PostSortType postSortType, // 최신순, 인기순, 이름순

--- a/src/main/java/com/sejong/elasticservice/domain/project/dto/ProjectSearchDto.java
+++ b/src/main/java/com/sejong/elasticservice/domain/project/dto/ProjectSearchDto.java
@@ -1,5 +1,6 @@
 package com.sejong.elasticservice.domain.project.dto;
 
+import com.sejong.elasticservice.domain.UserInfo;
 import com.sejong.elasticservice.domain.project.domain.ProjectDocument;
 import com.sejong.elasticservice.domain.project.domain.ProjectStatus;
 import lombok.AllArgsConstructor;
@@ -25,6 +26,9 @@ public class ProjectSearchDto {
     private String updatedAt;
     private long likeCount;
     private long viewCount;
+    
+    private UserInfo owner;
+    private List<UserInfo> collaborators;
 
     public static ProjectSearchDto from(ProjectDocument document) {
         return ProjectSearchDto.builder()
@@ -39,6 +43,10 @@ public class ProjectSearchDto {
                 .updatedAt(document.getUpdatedAt())
                 .likeCount(document.getLikeCount())
                 .viewCount(document.getViewCount())
+                .owner(UserInfo.from(document.getOwner()))
+                .collaborators(document.getCollaborators() != null 
+                        ? document.getCollaborators().stream().map(UserInfo::from).toList() 
+                        : List.of())
                 .build();
     }
 }

--- a/src/main/java/com/sejong/elasticservice/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/sejong/elasticservice/domain/project/repository/ProjectRepositoryImpl.java
@@ -71,10 +71,14 @@ public class ProjectRepositoryImpl implements ProjectRepository {
                 .fuzziness("AUTO")
         )._toQuery();
 
-        Query projectStatusFilter = TermQuery.of(t -> t
-                .field("projectStatus")
-                .value(projectStatus.name())
-        )._toQuery();
+        List<Query> filters = new ArrayList<>();
+        if (projectStatus != null) {
+            Query projectStatusFilter = TermQuery.of(t -> t
+                    .field("projectStatus")
+                    .value(projectStatus.name())
+            )._toQuery();
+            filters.add(projectStatusFilter);
+        }
 
         List<FieldValue> categoryValues = categories.stream()
                 .map(FieldValue::of)
@@ -93,11 +97,6 @@ public class ProjectRepositoryImpl implements ProjectRepository {
                 .field("projectTechStacks")
                 .terms(v -> v.value(techStackValues))
         )._toQuery();
-
-        List<Query> filters = new ArrayList<>();
-        if (projectStatus != null && !projectStatus.name().isBlank()) {
-            filters.add(projectStatusFilter);
-        }
         if (!categories.isEmpty()) filters.add(projectCategoriesFilter);
         if (!techStacks.isEmpty()) filters.add(projectTechStacksFilter);
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -74,13 +74,13 @@ app:
   kafka:
     topic: project-events
 
-#management:
-#  server:
-#    port: 18080  #이거는 매트릭을 수집하기 위한 고정 포트다.
-#  endpoints:
-#    web:
-#      exposure:
-#        include: health,info,prometheus,metrics
-#  endpoint:
-#    health:
-#      show-details: always
+management:
+  server:
+    port: 0  #이거는 매트릭을 수집하기 위한 고정 포트다.
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
## #️⃣ 이슈

- close #이슈번호

## 🔎 작업 내용

### 1. Elasticsearch 인덱스 초기화 방식 변경
- 서버 시작 시 기존 인덱스를 삭제 후 재생성하도록 `ElasticsearchIndexInitializer` 수정
- 개발 환경에서 매번 깨끗한 상태로 시작할 수 있도록 변경

### 2. SearchDto 응답에 사용자 정보 추가
- `UserInfo` DTO 클래스 생성 (username, nickname, realname 포함)
- `ProjectSearchDto`, `NewsSearchDto`, `CsKnowledgeSearchDto`에 사용자 정보 필드 추가
  - Project: `owner` (UserInfo), `collaborators` (List<UserInfo>)
  - News: `writer` (UserInfo), `participants` (List<UserInfo>)
  - CS Knowledge: `writer` (UserInfo)

### 3. Search API 파라미터 Optional 처리
- 모든 search API에서 requestParam이 빈값이거나 공백일 경우 전체 조회되도록 수정
- Project: `query`, `projectStatus`를 optional로 변경
- Document: `query`를 optional로 변경하고 Repository에서 빈값 처리 추가
- News, CS Knowledge: 이미 optional로 구현되어 있어 변경 없음

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

- 서버 시작 시 인덱스 삭제/재생성은 개발 환경에 적합합니다. 운영 환경에서는 제외하거나 프로파일 분리 검토가 필요합니다.
- `UserInfo` DTO의 위치(`common/dto` vs `domain/dto`)와 네이밍 컨벤션 검토가 필요합니다.

## 🧲 참고 자료 및 공유 사항
<img width="430" height="422" alt="image" src="https://github.com/user-attachments/assets/302b9e7a-c17f-4319-ac56-44a7e7ecb67b" />
